### PR TITLE
Update ConvertFromTable() function

### DIFF
--- a/Scripts/jquery.battatech.excelexport.js
+++ b/Scripts/jquery.battatech.excelexport.js
@@ -83,7 +83,7 @@
         }
 
         function ConvertFromTable() {
-            var result = $("#" + $settings.containerid).parent().html();
+            var result = $('<div>').append($('#' + $settings.containerid ).clone()).html();
             return result;
         }
 


### PR DESCRIPTION
Unexpected behaviour of extra html tags being included in the export of the Excel Export. The general conscience is to clone the table and append it to a jQuery object and then acquire the true html of the table.
