### PR TITLE
add ability to set the worksheet name

### DIFF
--- a/Scripts/jquery.battatech.excelexport.js
+++ b/Scripts/jquery.battatech.excelexport.js
@@ -167,7 +167,7 @@
             excelFile += "</html>";
 
             var uri = "data:application/vnd.ms-excel;base64,";
-            var ctx = { worksheet: name || 'Worksheet', table: htmltable };
+            var ctx = { worksheet: $settings.worksheetName || 'Worksheet', table: htmltable };
 
             return (uri + base64(format(excelFile, ctx)));           
         }


### PR DESCRIPTION
uses a simple setting: 
var options = {
   ...,
   worksheetName: 'My Custom Name'
}
